### PR TITLE
Split checks

### DIFF
--- a/.ddev/commands/web/md
+++ b/.ddev/commands/web/md
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+## Description: Run PHPMD on a specific module.
+## Usage: md MODULE_NAME
+## Example: "ddev md admin_toolbar"
+
+if [ $# -eq 0 ]
+then
+  echo "You must specify a module; e.g. 'ddev md admin_toolbar'"
+  exit
+fi
+
+if [ ! -d "web/modules/contrib/$1" ]
+then
+  echo "The specified module [$1] does not exist in /web/modules/contrib."
+  exit
+fi
+
+echo "======================"
+echo "Running PHPMD against: /web/modules/contrib/$1"
+echo "======================"
+vendor/bin/phpmd web/modules/contrib/$1 text codesize,design,naming "php,inc,module,theme,profile,install,test"

--- a/.ddev/commands/web/sniff
+++ b/.ddev/commands/web/sniff
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+## Description: Run php code sniffer on a specific module.
+## Usage: sniff MODULE_NAME
+## Example: "ddev snigg admin_toolbar"
+
+if [ $# -eq 0 ]
+then
+  echo "You must specify a module; e.g. 'ddev sniff admin_toolbar'"
+  exit
+fi
+
+if [ ! -d "web/modules/contrib/$1" ]
+then
+  echo "The specified module [$1] does not exist in /web/modules/contrib."
+  exit
+fi
+
+echo "======================"
+echo "Running code sniffer against: /web/modules/contrib/$1"
+echo "======================"
+
+# auto-fix what can be fixed
+echo "--------------"
+echo "Running PHPCBF"
+echo "--------------"
+vendor/bin/phpcbf web/modules/contrib/$1 --standard="Drupal,DrupalPractice" -n --extensions="php,module,inc,install,test,profile,theme"
+# find what is left to fix
+echo "-------------"
+echo "Running PHPCS"
+echo "-------------"
+vendor/bin/phpcs web/modules/contrib/$1 --standard="Drupal,DrupalPractice" -n --extensions="php,module,inc,install,test,profile,theme"

--- a/.ddev/commands/web/stan
+++ b/.ddev/commands/web/stan
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Description: Run phpstan on a specific module.
+## Usage: stan MODULE_NAME
+## Example: "ddev stan admin_toolbar"
+
+if [ $# -eq 0 ]
+then
+  echo "You must specify a module; e.g. 'ddev stan admin_toolbar'"
+  exit
+fi
+
+if [ ! -d "web/modules/contrib/$1" ]
+then
+  echo "The specified module [$1] does not exist in /web/modules/contrib."
+  exit
+fi
+
+echo "======================"
+echo "Running PHPStan against: /web/modules/contrib/$1"
+echo "======================"
+
+vendor/bin/phpstan analyse web/modules/contrib/$1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ We have automated common tasks as ddev commands to reduce dependencies. The foll
 
 **Example:** `ddev check admin_toolbar`
 
-The `check` command will run code reviews using PHPCBF, PHPCS, PHPMD, and PHPStan against the selected module.
+The `check` command will run code reviews using PHPCBF, PHPCS, PHPMD, and PHPStan against the selected module. PHPCBF may change the module's code as part of this action.
+
+These commands can also be run individually as `ddev md`, `ddev sniff`, and `ddev stan`.
 
 ### ddev cleanup
 
@@ -83,6 +85,14 @@ Note that this command will `delete` an existing copy of the module.
 
 Installs the default drupal site.
 
+### ddev md
+
+**Command:** `ddev md MODULE`
+
+**Example:** `ddev md admin_toolbar`
+
+The `md` command will run code reviews using PHPMD against the selected module.
+
 ### ddev rector
 
 **Command:** `ddev rector MODULE` or `ddev rector MODULE -d` or `ddev rector MODULE --dry-run`
@@ -91,7 +101,7 @@ Installs the default drupal site.
 
 **Example:** `ddev rector admin_toolbar -d`
 
-The `rector` command will run Drupal Rector updates against the selected module. Using the `-d` or `--dry-run` flag will not perform the changes, but instead show the suggested changes.
+The `rector` command will run Drupal Rector updates against the selected module, potentially rewriting the module's code. Using the `-d` or `--dry-run` flag will not perform the changes, but instead show the suggested changes.
 
 ### ddev remove
 
@@ -100,6 +110,22 @@ The `rector` command will run Drupal Rector updates against the selected module.
 **Example:** `ddev rector admin_toolbar`
 
 The `ddev remove` command will uninstall a module and delete it from the `web/modules/contrib` directory.
+
+### ddev sniff
+
+**Command:** `ddev sniff MODULE`
+
+**Example:** `ddev sniff admin_toolbar`
+
+The `sniff` command will run code reviews using PHPCBF and PHPCS against the selected module. PHPCBF may change the module's code as part of this action.
+
+### ddev stan
+
+**Command:** `ddev stan MODULE`
+
+**Example:** `ddev stan admin_toolbar`
+
+The `stan` command will run code reviews using PHPStan against the selected module.
 
 ### ddev test
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ includes:
 	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- vendor/mglaman/phpstan-drupal/extension.neon
 parameters:
-  level: 2
+  level: 8
   checkGenericClassInNonGenericObjectType: false
   checkMissingIterableValueType: false
   ignoreErrors:


### PR DESCRIPTION
Allows the `ddev check` commands to be run individually.

Bump PHPStan level to 8, per druypal-check config.