### PR TITLE
Adds support for FunctionalJavaScript and Nightwatch testing

### DIFF
--- a/.ddev/config.selenium-standalone-chrome.yaml
+++ b/.ddev/config.selenium-standalone-chrome.yaml
@@ -1,0 +1,27 @@
+#ddev-generated
+# Remove the line above if you don't want this file to be overwritten when you run
+# ddev get drud/ddev-selenium-standalone-chrome
+#
+# This file comes from https://github.com/drud/ddev-selenium-standalone-chrome
+#
+web_environment:
+  - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
+  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
+  - SIMPLETEST_BASE_URL=http://web
+  - SIMPLETEST_DB=mysql://db:db@db/db
+  # Use disable-dev-shm-usage instead of setting shm_usage
+  # https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
+  # The format of chromeOptions is defined at https://chromedriver.chromium.org/capabilities
+  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  # Nightwatch
+  - DRUPAL_TEST_BASE_URL=http://web
+  - DRUPAL_TEST_DB_URL=mysql://db:db@db/db
+  - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
+  - DRUPAL_TEST_WEBDRIVER_PORT=4444
+  - DRUPAL_TEST_WEBDRIVER_PATH_PREFIX=/wd/hub
+  - DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false
+  - DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY=../
+  - DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
+  - DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
+  - DTT_BASE_URL=http://web
+  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]

--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -1,0 +1,33 @@
+#ddev-generated
+# Remove the line above if you don't want this file to be overwritten when you run
+# ddev get drud/ddev-selenium-standalone-chrome
+#
+# This file comes from https://github.com/drud/ddev-selenium-standalone-chrome
+#
+version: '3.6'
+services:
+  selenium-chrome:
+    image: seleniarm/standalone-chromium:4.1.4-20220429
+    container_name: ddev-${DDEV_SITENAME}-selenium-chrome
+    expose:
+      #      The internal noVNC port, which operates over HTTP so it can be exposed
+      #      through the router.
+      - 7900
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTPS_EXPOSE=7900:7900
+      - HTTP_EXPOSE=7910:7900
+    external_links:
+      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
+      #ports:
+      # VNC access for a traditional VNC client like macOS "Screen Sharing".
+      # - "5900:5900"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - ".:/mnt/ddev_config"
+
+  web:
+    links:
+      - selenium-chrome


### PR DESCRIPTION
To test:

* Do not check out this branch yet!
* Run `ddev clone token` and `ddev clone pathauto`
* Run `ddev test pathauto`
* Notice FunctionalJavaScript tests are skipped (`....SSSSS....` in the output)
* Checkout this branch
* Run `ddev restart`
* Run `ddev test pathauto`
* Notice all tests are run (see `/Drupal_Tests_pathauto_FunctionalJavascript_PathautoUiTest` in the browser output)