### PR TITLE
TECH-72: Add branch and tag options to ddev clone command

### DIFF
--- a/.ddev/commands/web/clone
+++ b/.ddev/commands/web/clone
@@ -34,7 +34,7 @@ do
 done
 
 # Ensure that user did not specify both a tag and a branch.
-if [ -z "$TAG" ] && [ -z "$BRANCH" ]
+if [ ! -z "$TAG" ] && [ ! -z "$BRANCH" ]
 then
   echo "You cannot specify both a tag and a branch."
   help
@@ -75,11 +75,11 @@ fi
 
 # If specified, check out a branch or tag.
 cd $MODULE
-if [ "$TAG" != "default" ]
+if [ ! -z $TAG ]
 then
   echo "git checkout $TAG -b $TAG"
   git checkout "$TAG" -b "$TAG"
-elif [ "$BRANCH" != "default" ]
+elif [ ! -z "$BRANCH" ]
 then
   echo "git checkout --track origin/$BRANCH"
   git checkout --track origin/"$BRANCH"

--- a/.ddev/commands/web/clone
+++ b/.ddev/commands/web/clone
@@ -1,21 +1,52 @@
 #!/bin/bash
 
 ## Description: Checkout a module using git clone
-## Usage: clone MODULE_NAME [-y]
-## Example: "ddev clone admin_toolbar" or "ddev clone admin_toolbar -y"
+## Usage: clone [-b BRANCH_NAME | -t TAG_NAME] [-m] MODULE_NAME
+## Example: "ddev clone admin_toolbar" or "ddev clone -b develop -m admin_toolbar"
 
-if [ $# -eq 0 ]
-then
-  echo "You must specify a module; e.g. 'ddev check admin_toolbar'"
+help() {
+  echo "Usage: clone [-b BRANCH_NAME | -t TAG_NAME] [-m] MODULE_NAME"
+  echo "Options:"
+  echo "  -b    Specify a branch to check out."
+  echo "  -t    Specify a tag to check out."
+  echo "  -m    Clone the repo as a maintainer."
   exit
-fi
+}
 
 TYPE="contributor"
-MODULE="$1"
 
-if [ $# -eq 2 ] && [ "$2" = "-y" ]
+while getopts 'b:t:m' opt
+do
+  case $opt in
+    b)
+      BRANCH="$OPTARG"
+      ;;
+    t)
+      TAG="$OPTARG"
+      ;;
+    m)
+      TYPE="maintainer"
+      ;;
+    ?)
+      help
+      ;;
+  esac
+done
+
+# Ensure that user did not specify both a tag and a branch.
+if [ -z "$TAG" ] && [ -z "$BRANCH" ]
 then
-  TYPE="maintainer"
+  echo "You cannot specify both a tag and a branch."
+  help
+fi
+
+# Retrieve the module name from the end of the argument list.
+shift $((OPTIND-1))
+if [ -z $1 ]; then
+  echo "You must specify a module; e.g. 'ddev check admin_toolbar'"
+  help
+else
+  MODULE=$1
 fi
 
 echo "============"
@@ -29,6 +60,8 @@ then
   rm -rf "web/modules/contrib/$MODULE"
 fi
 
+# Create the contrib directory if it does not exist.
+mkdir -p web/modules/contrib
 cd web/modules/contrib
 
 if [ "$TYPE" = "contributor" ]
@@ -40,9 +73,22 @@ else
   git clone "git@git.drupal.org:project/$MODULE.git"
 fi
 
+# If specified, check out a branch or tag.
+cd $MODULE
+if [ "$TAG" != "default" ]
+then
+  echo "git checkout $TAG -b $TAG"
+  git checkout "$TAG" -b "$TAG"
+elif [ "$BRANCH" != "default" ]
+then
+  echo "git checkout --track origin/$BRANCH"
+  git checkout --track origin/"$BRANCH"
+fi
+
 # Notify about composer install if the module has dependencies.
 if [ -f "web/modules/contrib/$MODULE/composer.json" ]
 then
   echo "This module contains a composer.json file."
   echo "You may need to run composer install from the project root."
 fi
+


### PR DESCRIPTION
Adds branch and tag options to ddev clone command.

### Notes
- Changed the 'clone as maintainer' option from `-y` to `-m` because of the addition of the other options.

### Testing instructions
#### Branch functionality
- `ddev clone -b  8.x-1.x admin_toolbar`
- `cd web/modules/contrib/admin_toolbar/`
- `git branch`
  - Ensure that the current branch is `8.x-1.x`. The default is `3.x`.

#### Tag functionality
- `ddev clone -t 3.0.2 admin_toolbar`
- `cd web/modules/contrib/admin_toolbar/`
- `git describe --tags`
  - Ensure that the current tag is `3.0.2`.

#### Maintainer functionality
- `ddev clone -m admin_toolbar`
  - Ensure that the module is checked out using `ssh` rather than `https`.

#### Default functionality
- `ddev clone admin_toolbar`
  - Ensure that the module can be cloned without any options.

#### Errors
- Ensure that the script keeps the user from specifying both a tag and a branch.
  - `ddev clone -b 8.x-1.x -t 3.0.2 admin_toolbar`
  - The help window should appear.