### PR TITLE
TECH-53: document php 8 1 testing steps

### DIFF
--- a/.ddev/commands/web/check
+++ b/.ddev/commands/web/check
@@ -4,6 +4,8 @@
 ## Usage: check MODULE_NAME
 ## Example: "ddev check admin_toolbar"
 
+COMMAND_DIR=$(dirname $(realpath "$0"))
+
 if [ $# -eq 0 ]
 then
   echo "You must specify a module; e.g. 'ddev check admin_toolbar'"
@@ -30,6 +32,9 @@ echo "-------------"
 echo "Running PHPCS"
 echo "-------------"
 vendor/bin/phpcs web/modules/contrib/$1 --standard="Drupal,DrupalPractice" -n -p --colors --extensions="php,module,inc,install,test,profile,theme,info,yml,css,js"
+# Run phpversion
+"$COMMAND_DIR"/phpversion $1
+exit
 echo "-------------"
 echo "Running PHPMD"
 echo "-------------"

--- a/.ddev/commands/web/phpversion
+++ b/.ddev/commands/web/phpversion
@@ -1,23 +1,58 @@
 #!/bin/bash
 
 ## Description: Run php code sniffer with PHP Compatibility coding standard on a specific module.
-## Usage: phpversion [-v VERSION] MODULE_NAME
-## Example: "ddev phpversion -v 8.1 admin_toolbar"
+## Usage: phpversion MODULE_NAME [-v VERSION]
+## Example: "ddev phpversion admin_toolbar -v 8.1"
 
 help() {
-  echo "Usage: phpversion [-v VERSION] MODULE_NAME"
+  echo "Usage: phpversion MODULE_NAME [-v VERSION]"
   echo "Options:"
-  echo "  -v    Specify a PHP version to test. Defaults to PHP 8.1."
+  echo "  -v    Specify a PHP version to test against. Defaults to PHP 8.1."
   exit
 }
 
+# Set getopts flags. Numeric flags are positional arguments and must be followed by a colon.
+FLAGS='v:1:'
+
+# Assign ascending numeric flags to positional arguments.
+POS_ARG_CT=0
+OPTION_EXPECTS_ARG=0
+for arg in "$@"
+do
+  shift
+  case "$arg" in
+    \-*)
+      if [[ "$FLAGS" = *"$(echo $arg | sed 's/-//g'):"* ]]
+      then
+        OPTION_EXPECTS_ARG=1
+      fi
+      set -- "$@" "$arg"
+      ;;
+    *)
+      if [ $OPTION_EXPECTS_ARG = 0 ]
+      then
+        POS_ARG_CT=$((POS_ARG_CT+1))
+        set -- "$@" "-$POS_ARG_CT" "$arg"
+      else
+        OPTION_EXPECTS_ARG=0
+        set -- "$@" "$arg"
+      fi
+      ;;
+  esac
+done
+
 PHP_VERSION="8.1"
 
-while getopts 'v:' opt
+while getopts $FLAGS opt
 do
   case $opt in
+    # Flagged arguments
     v)
       PHP_VERSION="$OPTARG"
+      ;;
+    # Positional arguments
+    1)
+      MODULE="$OPTARG"
       ;;
     ?)
       help
@@ -25,22 +60,19 @@ do
   esac
 done
 
-# Retrieve the module name from the end of the argument list.
-shift $((OPTIND-1))
-if [ -z $1 ]; then
-  echo "You must specify a module; e.g. 'ddev phpversion admin_toolbar'"
+if [ -z "$MODULE" ]
+then
+  echo "You must specify a module; e.g. 'ddev clone admin_toolbar'"
   help
-else
-  MODULE=$1
 fi
 
-if [ ! -d "web/modules/contrib/$1" ]
+if [ ! -d "web/modules/contrib/$MODULE" ]
 then
-  echo "The specified module [$1] does not exist in /web/modules/contrib."
+  echo "The specified module [$MODULE] does not exist in /web/modules/contrib."
   exit
 fi
 
 echo "--------------------------------------------------"
 echo "Testing $MODULE for PHP $PHP_VERSION compatibility"
 echo "--------------------------------------------------"
-vendor/bin/phpcs -p web/modules/contrib/$1 --standard="PHPCompatibility" --runtime-set testVersion "$PHP_VERSION" --extensions="php,module,inc,install,test,profile,theme"
+vendor/bin/phpcs -p web/modules/contrib/$MODULE --standard="PHPCompatibility" --runtime-set testVersion "$PHP_VERSION" --extensions="php,module,inc,install,test,profile,theme"

--- a/.ddev/commands/web/phpversion
+++ b/.ddev/commands/web/phpversion
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+## Description: Run php code sniffer with PHP Compatibility coding standard on a specific module.
+## Usage: phpversion [-v VERSION] MODULE_NAME
+## Example: "ddev phpversion -v 8.1 admin_toolbar"
+
+help() {
+  echo "Usage: phpversion [-v VERSION] MODULE_NAME"
+  echo "Options:"
+  echo "  -v    Specify a PHP version to test. Defaults to PHP 8.1."
+  exit
+}
+
+PHP_VERSION="8.1"
+
+while getopts 'v:' opt
+do
+  case $opt in
+    v)
+      PHP_VERSION="$OPTARG"
+      ;;
+    ?)
+      help
+      ;;
+  esac
+done
+
+# Retrieve the module name from the end of the argument list.
+shift $((OPTIND-1))
+if [ -z $1 ]; then
+  echo "You must specify a module; e.g. 'ddev phpversion admin_toolbar'"
+  help
+else
+  MODULE=$1
+fi
+
+if [ ! -d "web/modules/contrib/$1" ]
+then
+  echo "The specified module [$1] does not exist in /web/modules/contrib."
+  exit
+fi
+
+echo "--------------------------------------------------"
+echo "Testing $MODULE for PHP $PHP_VERSION compatibility"
+echo "--------------------------------------------------"
+vendor/bin/phpcs -p web/modules/contrib/$1 --standard="PHPCompatibility" --runtime-set testVersion "$PHP_VERSION" --extensions="php,module,inc,install,test,profile,theme"

--- a/.ddev/commands/web/sniff
+++ b/.ddev/commands/web/sniff
@@ -4,6 +4,8 @@
 ## Usage: sniff MODULE_NAME
 ## Example: "ddev sniff admin_toolbar"
 
+COMMAND_DIR=$(dirname $(realpath "$0"))
+
 if [ $# -eq 0 ]
 then
   echo "You must specify a module; e.g. 'ddev sniff admin_toolbar'"
@@ -30,3 +32,5 @@ echo "-------------"
 echo "Running PHPCS"
 echo "-------------"
 vendor/bin/phpcs web/modules/contrib/$1 --standard="Drupal,DrupalPractice" -n -p --colors --extensions="php,module,inc,install,test,profile,theme,info,yml,css,js"
+# Run phpversion
+"$COMMAND_DIR"/phpversion $1

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ The `md` command will run code reviews using PHPMD against the selected module.
 
 ### ddev phpversion
 
-**Command:** `ddev phpversion [-v VERSION] MODULE`
+**Command:** `ddev phpversion MODULE [-v VERSION]`
 
 **Example:** `ddev phpversion admin_toolbar`
 
-**Example:** `ddev phpversion -v 7.4 admin_toolbar`
+**Example:** `ddev phpversion admin_toolbar -v 7.4`
 
 The `phpversion` command will run PHPCS against the selected module using the `PHPCompatibility` coding standard.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Installs the default drupal site.
 
 The `md` command will run code reviews using PHPMD against the selected module.
 
+### ddev phpversion
+
+**Command:** `ddev phpversion [-v VERSION] MODULE`
+
+**Example:** `ddev phpversion admin_toolbar`
+
+**Example:** `ddev phpversion -v 7.4 admin_toolbar`
+
+The `phpversion` command will run PHPCS against the selected module using the `PHPCompatibility` coding standard.
+
+Use the `-v` flag to specify a PHP version to test. By default, the version is `8.1`.
+
 ### ddev rector
 
 **Command:** `ddev rector MODULE` or `ddev rector MODULE -d` or `ddev rector MODULE --dry-run`

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "mglaman/drupal-check": "^1.4",
     "mikey179/vfsstream": "^1.6",
     "palantirnet/drupal-rector": "^0.15.0",
+    "phpcompatibility/php-compatibility": "^9.3",
     "phpmd/phpmd": "^2.13",
     "phpspec/prophecy": "^1.16",
     "phpspec/prophecy-phpunit": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d7234c60d3010881e07b18e7dfdf50d",
+    "content-hash": "008e4d68074c7b5e20bc0d2d648d03e0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7646,6 +7646,68 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION
## Overview
Adds `phpversion` command to `.ddev/commands/web`.

## Testing
### PHP versioning
- `ddev clone admin_toolbar -c`
- `ddev phpversion admin_toolbar`
  - Ensure that `phpversion` is run with version `8.1`. There should be no errors.
- `ddev phpversion admin_toolbar -v 5.0`
  - Ensure that `phpversion` is run with version `5.0`. There should be numerous errors.
### PHP 8.1 errors
I cannot find an example of a module that will throw PHP errors. I've gone as far back as Drupal 5 branches. However, the Drupal 6 repo will throw some errors.
- `ddev clone drupal -b 6.x -c`
- `ddev phpversion drupal`
  - This should throw many warnings and errors.
- `ddev phpversion drupal -v 5.2`
  - This should throw far fewer errors, demonstrating that the version testing is working properly.
