### PR TITLE
Don't require nfs at the project level

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,7 +11,7 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.4"
-nfs_mount_enabled: true
+nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,7 +11,6 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.4"
-nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"


### PR DESCRIPTION
Developers should be able to choose the DDEV file-sharing method that works best for them (NFS, VirtioFS etc.). Developers often set this option at the global level (`ddev config global --nfs-mount-enabled`). With this option set at the project level, developers using alternative file-sharing methods will receive the following error:

`Error response from daemon: error while mounting volume ... permission denied`

## Testing

- `ddev poweroff`
- Make sure NFS is enabled globally (see above).
- `ddev start`
- Verify NFS is being used: `ddev debug nfsmount`
- `ddev poweroff`
- Make sure NFS is not enabled globally.
- `ddev start`
- Verify NFS is not being used. 
